### PR TITLE
Use a rewrite rule to get the efficient Core

### DIFF
--- a/Eval1.hs
+++ b/Eval1.hs
@@ -27,3 +27,13 @@ runEval m = do
     ref <- newIORef 0
     runReaderT (runReaderT m ref) ref
     readIORef ref
+
+bindEval
+  :: Eval a
+  -> (a -> Eval b)
+  -> Eval b
+bindEval m k = readerT $ \x -> readerT $ \y -> do
+    a <- runReaderT (runReaderT m x) y
+    runReaderT (runReaderT (k a) x) y
+{-# INLINE bindEval #-}
+{-# RULES "rewrite >>= for Eval" (>>=) = bindEval #-}

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,37 @@ PHONY: core
 
 OBJ=build
 COMPILE=ghc --make -outputdir $(OBJ) -i$(OBJ) -L$(OBJ)
+GHC_OPTS=-O -ddump-simpl
 
 # Compile and inspect core for the inner loop
 MODULE=OptimizeMonadTrans
 
 core1 :
 	$(COMPILE) -DEVAL=Eval1 -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTS) \
 		$(MODULE).hs > results/$(MODULE).core1.hs
 
 core2 :
 	$(COMPILE) -DEVAL=Eval2 -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTS) \
 		$(MODULE).hs > results/$(MODULE).core2.hs
 
 core3 :
 	$(COMPILE) -DEVAL=Eval3 -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTSｓ) \
 		$(MODULE).hs > results/$(MODULE).core3.hs
 
 core3s :
 	$(COMPILE) -DEVAL=Eval3 -DSHARING -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTS) \
 		$(MODULE).hs > results/$(MODULE).core3s.hs
 
 coreImplicit :
 	$(COMPILE) -DEVAL=Eval1 -DIMPLICIT -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTS) \
 		$(MODULE).hs > results/$(MODULE).coreImplicit.hs
 
 coreRefl :
 	$(COMPILE) -DEVAL=Eval1 -DREFLECTION -fforce-recomp \
-		-O -ddump-simpl \
+		$(GHC_OPTS) \
 		$(MODULE).hs > results/$(MODULE).coreRefl.hs

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PHONY: core
 
 OBJ=build
 COMPILE=ghc --make -outputdir $(OBJ) -i$(OBJ) -L$(OBJ)
-GHC_OPTS=-O -ddump-simpl
+GHC_OPTS=-O -ddump-simpl -dsuppress-coercions -dsuppress-uniques
 
 # Compile and inspect core for the inner loop
 MODULE=OptimizeMonadTrans

--- a/Reader.hs
+++ b/Reader.hs
@@ -10,6 +10,13 @@ import Control.Monad.Trans.Class
 
 newtype ReaderT r m a = R { runReaderT :: r -> m a }
 
+instance Functor m => Functor (ReaderT r m) where
+  fmap f (R g) = R $ \r -> f <$> g r
+
+instance Applicative m => Applicative (ReaderT r m) where
+  pure a = R $ \r -> pure a
+  R f <*> R a = R $ \r -> f r <*> a r
+
 instance Monad m => Monad (ReaderT r m) where
     (>>=)  = bindR
     return = returnR


### PR DESCRIPTION
I found that a hand-written bind for the `Eval` monad (`bindEval`) with a simple rewrite rule is sufficient to get the efficient Core.

We could generalize the type signature of `bindEval` but apparently we couldn't generalize the rewrite rule over the base monad like this:

```
{-# RULES
"rewrite >>= for Eval"
  forall (m :: Monad m => ReaderT r1 (ReaderT r2 m a)) k.
    m >>= k = bindEval m k
  #-}
```

GHC doesn't seem to fire this rule for some reason. If we replaced `m` with `IO`, the rule would fire.

So there's a way to get the efficient Core without changing either the monad transformer stack or the monad transformer library, but we need to provide such a hand-written function, together with a rewrite rule per a combination of transformers and a base monad. This isn't ideal but I guess it's still a viable work-around for some cases.

## Implementation notes

* Added Functor and Applicative instances for post-AMP versions of GHC
* The changes to Makefile are not really relevant but just for convenience